### PR TITLE
Fix build compile error for DisposeSentinel.Create call

### DIFF
--- a/JacksonDunstanNativeCollections/NativeArray2D.cs
+++ b/JacksonDunstanNativeCollections/NativeArray2D.cs
@@ -691,11 +691,14 @@ namespace JacksonDunstan.NativeCollections
                 m_Length1 = length1,
                 m_Allocator = allocator
             };
+	
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
             DisposeSentinel.Create(
                 out array.m_Safety,
                 out array.m_DisposeSentinel,
                 1,
                 allocator);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
dispose sentinel calls with m_Safety variable was not wrapped with ENABLE_UNITY_COLLECTIONS_CHECKS macro